### PR TITLE
Fix Method Usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# IDE settings
+.vscode
+
 # Windows image file caches
 Thumbs.db
 ehthumbs.db

--- a/python/main.py
+++ b/python/main.py
@@ -838,8 +838,8 @@ class Microphone():
         self.devices = []
 
         #for each audio device, add to list of devices
-        for i in range(0,self.numdevices):
-            device_info = py_audio.get_device_info_by_host_api_device_index(0,i)
+        for i in range(0, self.numdevices):
+            device_info = py_audio.get_device_info_by_index(i)
             if device_info["maxInputChannels"] > 1:
                 self.devices.append(device_info)
 


### PR DESCRIPTION
## tl;dr
There might have been a mix up with the following available API calls
`get_device_info_by_index(device_index)`
`get_device_count()`
`get_host_api_count()`
`get_host_api_info_by_index(host_api_index)`
`get_device_info_by_host_api_device_index(host_api_index, host_api_device_index)`

The incorrect method was being used for finding the device which led to an IndexError. Since we're attempting to add all of the devices, we should be using the method 'get_device_info_by_index` which will properly fetch the amount of devices we have.

This issue was also raised in #47 and #53 

## Issue

Run `PyAudio().get_default_host_api_info()`

__Windows 10__
```
{'index': 0, 'structVersion': 1, 'type': 2, 'name': 'MME', 'deviceCount': 5, 'defaultInputDevice': 1, 'defaultOutputDevice': 3}
```

```
>>> for i in range(py_audio.get_device_count()):
...     device_info = py_audio.get_device_info_by_host_api_device_index(0, i)
...     print(device_info)
...
{'index': 0, 'structVersion': 2, 'name': 'Microsoft Sound Mapper - Input', 'hostApi': 0, 'maxInputChannels': 2, 'maxOutputChannels': 0, 'defaultLowInputLatency': 0.09, 'defaultLowOutputLatency': 0.09, 'defaultHighInputLatency': 0.18, 'defaultHighOutputLatency': 0.18, 'defaultSampleRate': 44100.0}
{'index': 1, 'structVersion': 2, 'name': 'VoiceMeeter Output (VB-Audio Vo', 'hostApi': 0, 'maxInputChannels': 8, 'maxOutputChannels': 0, 'defaultLowInputLatency': 0.09, 'defaultLowOutputLatency': 0.09, 'defaultHighInputLatency': 0.18, 'defaultHighOutputLatency': 0.18, 'defaultSampleRate': 44100.0}
{'index': 2, 'structVersion': 2, 'name': 'Microsoft Sound Mapper - Output', 'hostApi': 0, 'maxInputChannels': 0, 'maxOutputChannels': 2, 'defaultLowInputLatency': 0.09, 'defaultLowOutputLatency': 0.09, 'defaultHighInputLatency': 0.18, 'defaultHighOutputLatency': 0.18, 'defaultSampleRate': 44100.0}
{'index': 3, 'structVersion': 2, 'name': 'VoiceMeeter Input (VB-Audio Voi', 'hostApi': 0, 'maxInputChannels': 0, 'maxOutputChannels': 8, 'defaultLowInputLatency': 0.09, 'defaultLowOutputLatency': 0.09, 'defaultHighInputLatency': 0.18, 'defaultHighOutputLatency': 0.18, 'defaultSampleRate': 44100.0}
{'index': 4, 'structVersion': 2, 'name': 'Speakers (Realtek High Definiti', 'hostApi': 0, 'maxInputChannels': 0, 'maxOutputChannels': 8, 'defaultLowInputLatency': 0.09, 'defaultLowOutputLatency': 0.09, 'defaultHighInputLatency': 0.18, 'defaultHighOutputLatency': 0.18, 'defaultSampleRate': 44100.0}
Traceback (most recent call last):
  File "<stdin>", line 2, in <module>
  File "D:\Programs\Anaconda\envs\esp\lib\site-packages\pyaudio.py", line 852, in get_device_info_by_host_api_device_index
    host_api_device_index)
OSError: [Errno -9996] Invalid device
```

Looking into the docs further, we see that the `Invalid device` error is described as
```
A paInvalidDevice error code indicates that the hostApiDeviceIndex parameter is out of range.
```
source: [portaudio docs](http://portaudio.com/docs/v19-doxydocs/portaudio_8h.html#a54f306b5e5258323c95a27c5722258cd)

If I do `PyAudio().get_device_count()` , it lists 13 devices! That's way more than I have when I checked it using  `PyAudio().get_default_host_api_info()` and `PyAudio().get_host_api_count()` which lists 2. 

So what this means is if I try `PyAudio().get_device_info_by_host_api_device_index(0,index)`, I will always have an index error because the host only has 2 while I have 13 devices in total on my setup. Sometimes this will work seamlessly for people because their rig has the same amount of devices as their PortAudio Host APIs count.

The fix is to simply swap out the method call to `get_device_info_by_index(device_index)`